### PR TITLE
Fix pip install command and add docker instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+.ipynb_checkpoints
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Git
+.git/
+.gitignore
+
+# IDE
+.vscode/
+.idea/
+
+# Documentation
+README.md
+CLAUDE.md
+
+# Docker
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# OpenAI API Configuration
+OPENAI_API_KEY=your-openai-api-key-here

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,100 @@
+# Docker Setup
+
+This guide explains how to run the AI Language Tutor using Docker.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- OpenAI API key
+
+## Quick Start
+
+1. **Set up environment variables:**
+   ```bash
+   # Copy the example file
+   cp .env.example .env
+
+   # Edit .env and add your OpenAI API key
+   nano .env
+   ```
+
+2. **Configure the learning language (optional):**
+   Edit `utils/config.json` to set your target language:
+   ```json
+   {
+     "openai_model_name": "gpt-4o",
+     "temperature": 0.7,
+     "language": "Polish"
+   }
+   ```
+
+3. **Build and run:**
+   ```bash
+   docker-compose up -d
+   ```
+
+4. **Access the app:**
+   Open your browser to `http://localhost:8501`
+
+## Docker Commands
+
+```bash
+# Start the application
+docker-compose up -d
+
+# View logs
+docker-compose logs -f
+
+# Stop the application
+docker-compose down
+
+# Rebuild after code changes
+docker-compose up -d --build
+
+# Remove everything including volumes
+docker-compose down -v
+```
+
+## Data Persistence
+
+User data is stored in the `assets/` directory, which is mounted as a volume. This ensures your vocabulary, lesson plans, and chat history persist between container restarts.
+
+The following files are persisted:
+- `assets/user_vocabulary.json` - Your vocabulary list
+- `assets/lesson_plan.json` - Your lesson plans
+- `assets/lesson_plan_inputs.json` - Lesson plan settings
+- `assets/chat_history.json` - Conversation history
+
+## Configuration Changes
+
+The `utils/config.json` file is also mounted as a volume, so you can change the language or model settings without rebuilding the container:
+
+```bash
+# Edit the config
+nano utils/config.json
+
+# Restart to apply changes
+docker-compose restart
+```
+
+## Troubleshooting
+
+**Port already in use:**
+If port 8501 is already in use, edit `docker-compose.yml` and change the port mapping:
+```yaml
+ports:
+  - "8502:8501"  # Access via localhost:8502
+```
+
+**API key not working:**
+Verify your `.env` file contains a valid OpenAI API key:
+```bash
+cat .env
+```
+
+**Reset all data:**
+To start fresh, remove the assets directory contents:
+```bash
+rm assets/*.json
+docker-compose restart
+```

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -29,6 +29,24 @@ This guide explains how to run the AI Language Tutor using Docker.
    ```
 
 3. **Build and run:**
+   Create a `docker-compose.yml`:
+   ```yml
+   services:
+     language-tutor:
+       build: .
+       container_name: ai-language-tutor
+       ports:
+         - "8501:8501"
+       environment:
+         - OPENAI_API_KEY=${OPENAI_API_KEY}
+       volumes:
+         # Persist user data
+         - ./assets:/app/assets
+         # Mount config for easy changes without rebuilding
+         - ./utils/config.json:/app/utils/config.json
+       restart: unless-stopped
+   ```
+   and run the service:
    ```bash
    docker-compose up -d
    ```
@@ -36,24 +54,6 @@ This guide explains how to run the AI Language Tutor using Docker.
 4. **Access the app:**
    Open your browser to `http://localhost:8501`
 
-## Docker Commands
-
-```bash
-# Start the application
-docker-compose up -d
-
-# View logs
-docker-compose logs -f
-
-# Stop the application
-docker-compose down
-
-# Rebuild after code changes
-docker-compose up -d --build
-
-# Remove everything including volumes
-docker-compose down -v
-```
 
 ## Data Persistence
 
@@ -67,15 +67,7 @@ The following files are persisted:
 
 ## Configuration Changes
 
-The `utils/config.json` file is also mounted as a volume, so you can change the language or model settings without rebuilding the container:
-
-```bash
-# Edit the config
-nano utils/config.json
-
-# Restart to apply changes
-docker-compose restart
-```
+The `utils/config.json` file is also mounted as a volume, so you can change the language or model settings without rebuilding the container.
 
 ## Troubleshooting
 
@@ -87,10 +79,7 @@ ports:
 ```
 
 **API key not working:**
-Verify your `.env` file contains a valid OpenAI API key:
-```bash
-cat .env
-```
+Verify your `.env` file contains a valid OpenAI API key.
 
 **Reset all data:**
 To start fresh, remove the assets directory contents:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application files
+COPY . .
+
+# Create necessary directories
+RUN mkdir -p assets .streamlit
+
+# Copy and set permissions for entrypoint script
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+# Expose Streamlit port
+EXPOSE 8501
+
+# Use entrypoint script to set up secrets
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Create .streamlit directory if it doesn't exist
+mkdir -p /app/.streamlit
+
+# Create secrets.toml from environment variable
+cat > /app/.streamlit/secrets.toml <<EOF
+OPENAI_API_KEY = "${OPENAI_API_KEY}"
+EOF
+
+# Run Streamlit
+exec streamlit run app.py --server.address=0.0.0.0 --server.port=8501

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
-re
-json
 openai
 pandas
-random
-datetime
 streamlit


### PR DESCRIPTION
`pip install` fails because some of the packages are already built-in and cannot be found in the registry.

Also adds instructions to dockerize the application.